### PR TITLE
feat: Add UUID-based app launching with fallback to app ID

### DIFF
--- a/app/backend/nvapp.cpp
+++ b/app/backend/nvapp.cpp
@@ -2,6 +2,7 @@
 
 #define SER_APPNAME "name"
 #define SER_APPID "id"
+#define SER_APPUUID "uuid"
 #define SER_APPHDR "hdr"
 #define SER_APPCOLLECTOR "appcollector"
 #define SER_HIDDEN "hidden"
@@ -11,6 +12,7 @@ NvApp::NvApp(QSettings& settings)
 {
     name = settings.value(SER_APPNAME).toString();
     id = settings.value(SER_APPID).toInt();
+    uuid = settings.value(SER_APPUUID).toString();
     hdrSupported = settings.value(SER_APPHDR).toBool();
     isAppCollectorGame = settings.value(SER_APPCOLLECTOR).toBool();
     hidden = settings.value(SER_HIDDEN).toBool();
@@ -21,6 +23,7 @@ void NvApp::serialize(QSettings& settings) const
 {
     settings.setValue(SER_APPNAME, name);
     settings.setValue(SER_APPID, id);
+    settings.setValue(SER_APPUUID, uuid);
     settings.setValue(SER_APPHDR, hdrSupported);
     settings.setValue(SER_APPCOLLECTOR, isAppCollectorGame);
     settings.setValue(SER_HIDDEN, hidden);

--- a/app/backend/nvapp.h
+++ b/app/backend/nvapp.h
@@ -12,6 +12,7 @@ public:
     {
         return id == other.id &&
                 name == other.name &&
+                uuid == other.uuid &&
                 hdrSupported == other.hdrSupported &&
                 isAppCollectorGame == other.isAppCollectorGame &&
                 hidden == other.hidden &&
@@ -33,6 +34,7 @@ public:
 
     int id = 0;
     QString name;
+    QString uuid;
     bool hdrSupported = false;
     bool isAppCollectorGame = false;
     bool hidden = false;

--- a/app/backend/nvhttp.h
+++ b/app/backend/nvhttp.h
@@ -170,6 +170,7 @@ public:
     startApp(QString verb,
              bool isGfe,
              int appId,
+             QString appUuid,
              PSTREAM_CONFIGURATION streamConfig,
              bool sops,
              bool localAudio,

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1652,7 +1652,7 @@ bool Session::startConnectionAsync()
         NvHTTP http(m_Computer);
         http.startApp(m_Computer->currentGameId != 0 ? "resume" : "launch",
                       m_Computer->isNvidiaServerSoftware,
-                      m_App.id, &m_StreamConfig,
+                      m_App.id, m_App.uuid, &m_StreamConfig,
                       enableGameOptimizations,
                       m_Preferences->playAudioOnHost,
                       m_InputHandler->getAttachedGamepadMask(),


### PR DESCRIPTION
Implement support for launching applications using UUID identifiers, with automatic fallback to traditional app IDs when UUIDs are unavailable. This enhancement improves compatibility with Apollo/Sunshine servers that support UUID-based app identification.

Changes:
- Add `uuid` field to NvApp class with serialization support
- Update NvApp equality operator to include UUID comparison
- Modify NvHTTP::getAppList() to parse UUID from server responses
- Update NvHTTP::startApp() to prioritize UUID over app ID
- Enhance Session class to pass UUID to launch requests
- Implement clean parameter logic: use appuuid OR appid, not both

The implementation follows a UUID-first approach:
- If UUID is available: launch with "appuuid" parameter only
- If UUID is missing: fallback to traditional "appid" parameter
- Maintains backward compatibility with older server versions

This resolves app launching issues on modern Apollo servers while preserving compatibility with legacy GeForce Experience installations.