### PR TITLE
Implement Windows installer build using WiX Toolset

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -54,74 +54,93 @@ jobs:
         arch: 'win64_msvc2022_64'
         modules: 'qtmultimedia'
     
-    - name: Install dependencies
+    - name: Install WiX Toolset
       run: |
-        # Install vcpkg dependencies for Windows
-        vcpkg install sdl2:x64-windows sdl2-ttf:x64-windows opus:x64-windows ffmpeg:x64-windows openssl:x64-windows
-        # Set environment variables for vcpkg
-        echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
-        echo "CMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake" >> $env:GITHUB_ENV
+        choco install wixtoolset --version=5.0.1 -y
+        # Add WiX to PATH
+        echo "C:\Program Files (x86)\WiX Toolset v5.0\bin" >> $env:GITHUB_PATH
     
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
     
-    - name: Build
-      run: |
-        $env:PATH += ";$env:Qt6_DIR\bin"
-        $env:PATH += ";C:\vcpkg\installed\x64-windows\bin"
-        # Configure with vcpkg dependencies
-        qmake6 moonlight-qt.pro CONFIG+=release "INCLUDEPATH+=C:\vcpkg\installed\x64-windows\include" "LIBS+=-LC:\vcpkg\installed\x64-windows\lib"
-        nmake
-
-    - name: Build AntiHooking.dll
-      run: |
-        $env:PATH += ";$env:Qt6_DIR\bin"
-        cd AntiHooking
-        qmake6 AntiHooking.pro CONFIG+=release
-        nmake
-        cd ..
-
-    - name: Package Windows Development Build
+    - name: Update version file for development build
       env:
         VERSION: ${{ needs.setup-version.outputs.version }}
       run: |
-        mkdir windows-dev-package
-        copy app\release\moonlight.exe windows-dev-package\artemis-dev.exe
-
-        # Use windeployqt to bundle Qt dependencies
-        $env:PATH += ";$env:Qt6_DIR\bin"
-        windeployqt --release --no-translations --no-system-d3d-compiler --no-opengl-sw windows-dev-package\artemis-dev.exe
-
-        # Copy vcpkg DLLs manually
-        copy "libs\windows\lib\x64\*.dll" windows-dev-package\
-
-        # Copy AntiHooking.dll from build output
-        if (Test-Path "AntiHooking\release\AntiHooking.dll") {
-          copy "AntiHooking\release\AntiHooking.dll" windows-dev-package\
-        } else {
-          echo "Warning: AntiHooking.dll not found in AntiHooking/release/. Ensure it builds correctly." > windows-dev-package\ANTIHOOOKING_INFO.txt
-        }
-        # Create info file
-        echo "Artemis Desktop Development Build" > windows-dev-package\README.txt
-        echo "Version: $env:VERSION" >> windows-dev-package\README.txt
-        echo "Branch: ${{ github.ref_name }}" >> windows-dev-package\README.txt
-        echo "Commit: ${{ github.sha }}" >> windows-dev-package\README.txt
-        echo "Built: $(Get-Date)" >> windows-dev-package\README.txt
-        echo "" >> windows-dev-package\README.txt
-        echo "This package includes all necessary DLLs for running Artemis Desktop." >> windows-dev-package\README.txt
-        echo "Simply extract and run artemis-dev.exe" >> windows-dev-package\README.txt
-        echo "" >> windows-dev-package\README.txt
-        echo "Optional features:" >> windows-dev-package\README.txt
-        echo "- Discord RPC: Included" >> windows-dev-package\README.txt
-        echo "- AntiHooking: Included if build succeeded" >> windows-dev-package\README.txt
-
-        Compress-Archive -Path windows-dev-package\* -DestinationPath artemis-windows-$env:VERSION.zip
+        echo $env:VERSION > app\version.txt
     
-    - name: Upload Development Artifacts
+    - name: Build using build-artemis-arch.bat script
+      env:
+        VERSION: ${{ needs.setup-version.outputs.version }}
+      run: |
+        # Add Qt to PATH for the build script
+        $env:PATH = "$env:Qt6_DIR\bin;$env:PATH"
+        
+        # Run our Artemis build script that handles everything
+        cmd /c "scripts\build-artemis-arch.bat release"
+        
+        if ($LASTEXITCODE -ne 0) {
+          echo "Build failed with exit code $LASTEXITCODE"
+          exit $LASTEXITCODE
+        }
+    
+    - name: Rename artifacts for development build
+      env:
+        VERSION: ${{ needs.setup-version.outputs.version }}
+      run: |
+        # Find the generated MSI and portable ZIP files
+        $msiFile = Get-ChildItem -Path "build\installer-x64-release" -Filter "*.msi" | Select-Object -First 1
+        $zipFile = Get-ChildItem -Path "build\installer-x64-release" -Filter "ArtemisPortable-*.zip" | Select-Object -First 1
+        
+        if ($msiFile) {
+          # Rename MSI installer for Artemis
+          $newMsiName = "artemis-windows-installer-$env:VERSION.msi"
+          Move-Item $msiFile.FullName $newMsiName
+          echo "Created MSI installer: $newMsiName"
+        }
+        
+        if ($zipFile) {
+          # Rename portable ZIP for Artemis
+          $newZipName = "artemis-windows-portable-$env:VERSION.zip"
+          Move-Item $zipFile.FullName $newZipName
+          echo "Created portable ZIP: $newZipName"
+        }
+        
+        # Create info file
+        @"
+        Artemis Desktop Development Build
+        Version: $env:VERSION
+        Branch: ${{ github.ref_name }}
+        Commit: ${{ github.sha }}
+        Built: $(Get-Date)
+        
+        This build includes:
+        - MSI Installer with proper dependency handling
+        - Portable ZIP package
+        - All required Windows runtime dependencies
+        "@ | Out-File -FilePath "build_info.txt" -Encoding utf8
+    
+    - name: Upload MSI Installer
       uses: actions/upload-artifact@v4
       with:
-        name: artemis-windows-${{ needs.setup-version.outputs.version }}
-        path: artemis-windows-${{ needs.setup-version.outputs.version }}.zip
+        name: artemis-windows-installer-${{ needs.setup-version.outputs.version }}
+        path: artemis-windows-installer-${{ needs.setup-version.outputs.version }}.msi
+        retention-days: 30
+        if-no-files-found: warn
+    
+    - name: Upload Portable ZIP
+      uses: actions/upload-artifact@v4
+      with:
+        name: artemis-windows-portable-${{ needs.setup-version.outputs.version }}
+        path: artemis-windows-portable-${{ needs.setup-version.outputs.version }}.zip
+        retention-days: 30
+        if-no-files-found: warn
+    
+    - name: Upload Build Info
+      uses: actions/upload-artifact@v4
+      with:
+        name: artemis-windows-build-info-${{ needs.setup-version.outputs.version }}
+        path: build_info.txt
         retention-days: 30
 
   build-macos-dev:

--- a/scripts/build-artemis-arch.bat
+++ b/scripts/build-artemis-arch.bat
@@ -1,0 +1,243 @@
+@echo off
+setlocal enableDelayedExpansion
+
+rem Run from Qt command prompt with working directory set to root of repo
+
+set BUILD_CONFIG=%1
+
+rem Convert to lower case for windeployqt
+if /I "%BUILD_CONFIG%"=="debug" (
+    set BUILD_CONFIG=debug
+    set WIX_MUMS=10
+) else (
+    if /I "%BUILD_CONFIG%"=="release" (
+        set BUILD_CONFIG=release
+        set WIX_MUMS=10
+    ) else (
+        if /I "%BUILD_CONFIG%"=="signed-release" (
+            set BUILD_CONFIG=release
+            set SIGN=1
+            set MUST_DEPLOY_SYMBOLS=1
+
+            rem Fail if there are unstaged changes
+            git diff-index --quiet HEAD --
+            if !ERRORLEVEL! NEQ 0 (
+                echo Signed release builds must not have unstaged changes!
+                exit /b 1
+            )
+        ) else (
+            echo Invalid build configuration - expected 'debug' or 'release'
+            echo Usage: scripts\build-artemis-arch.bat ^(release^|debug^)
+            exit /b 1
+        )
+    )
+)
+
+rem Locate qmake and determine if we're using qmake.exe or qmake.bat
+rem qmake.bat is an ARM64 forwarder to the x64 version of qmake.exe
+where qmake.bat
+if !ERRORLEVEL! EQU 0 (
+    set QMAKE_CMD=call qmake.bat
+) else (
+    where qmake.exe
+    if !ERRORLEVEL! EQU 0 (
+        set QMAKE_CMD=qmake.exe
+    ) else (
+        where qmake6.exe
+        if !ERRORLEVEL! EQU 0 (
+            set QMAKE_CMD=qmake6.exe
+        ) else (
+            echo Unable to find QMake. Did you add Qt bins to your PATH?
+            goto Error
+        )
+    )
+)
+
+rem Find Qt path to determine our architecture
+for /F %%i in ('where qmake* ^| findstr .exe') do set QT_PATH=%%i
+
+rem Strip the qmake filename off the end to get the Qt bin directory itself
+set QT_PATH=%QT_PATH:\qmake.exe=%
+set QT_PATH=%QT_PATH:\qmake.bat=%
+set QT_PATH=%QT_PATH:\qmake.cmd=%
+set QT_PATH=%QT_PATH:\qmake6.exe=%
+
+echo QT_PATH=%QT_PATH%
+if not x%QT_PATH:_arm64=%==x%QT_PATH% (
+    set ARCH=arm64
+
+    rem Replace the _arm64 suffix with _64 to get the x64 bin path
+    set HOSTBIN_PATH=%QT_PATH:_arm64=_64%
+    echo HOSTBIN_PATH=!HOSTBIN_PATH!
+
+    if exist %QT_PATH%\windeployqt.exe (
+        echo Using windeployqt.exe from QT_PATH
+        set WINDEPLOYQT_CMD=windeployqt.exe
+    ) else (
+        echo Using windeployqt.exe from HOSTBIN_PATH
+        set WINDEPLOYQT_CMD=!HOSTBIN_PATH!\windeployqt.exe --qtpaths %QT_PATH%\qtpaths.bat
+    )
+) else (
+    if not x%QT_PATH:_64=%==x%QT_PATH% (
+        set ARCH=x64
+        set WINDEPLOYQT_CMD=windeployqt.exe
+    ) else (
+        if not x%QT_PATH:msvc=%==x%QT_PATH% (
+            set ARCH=x86
+            set WINDEPLOYQT_CMD=windeployqt.exe
+        ) else (
+            echo Unable to determine Qt architecture
+            goto Error
+        )
+    )
+)
+
+echo Detected target architecture: %ARCH%
+
+set SIGNTOOL_PARAMS=sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /sha1 8b9d0d682ad9459e54f05a79694bc10f9876e297 /v
+
+set BUILD_ROOT=%cd%\build
+set SOURCE_ROOT=%cd%
+set BUILD_FOLDER=%BUILD_ROOT%\build-%ARCH%-%BUILD_CONFIG%
+set DEPLOY_FOLDER=%BUILD_ROOT%\deploy-%ARCH%-%BUILD_CONFIG%
+set INSTALLER_FOLDER=%BUILD_ROOT%\installer-%ARCH%-%BUILD_CONFIG%
+set SYMBOLS_FOLDER=%BUILD_ROOT%\symbols-%ARCH%-%BUILD_CONFIG%
+set /p VERSION=<%SOURCE_ROOT%\app\version.txt
+
+rem Use the correct VC tools for the specified architecture
+if /I "%ARCH%" EQU "x64" (
+    rem x64 is a special case that doesn't match %PROCESSOR_ARCHITECTURE%
+    set VC_ARCH=AMD64
+) else (
+    set VC_ARCH=%ARCH%
+)
+
+rem If we're not building for the current platform, use the cross compiling toolchain
+if /I "%VC_ARCH%" NEQ "%PROCESSOR_ARCHITECTURE%" (
+    set VC_ARCH=%PROCESSOR_ARCHITECTURE%_%VC_ARCH%
+)
+
+rem Find Visual Studio and run vcvarsall.bat
+set VSWHERE="%SOURCE_ROOT%\scripts\vswhere.exe"
+for /f "usebackq delims=" %%i in (`%VSWHERE% -latest -property installationPath`) do (
+    call "%%i\VC\Auxiliary\Build\vcvarsall.bat" %VC_ARCH%
+)
+if !ERRORLEVEL! NEQ 0 goto Error
+
+rem Find VC redistributable DLLs
+for /f "usebackq delims=" %%i in (`%VSWHERE% -latest -find VC\Redist\MSVC\*\%ARCH%\Microsoft.VC*.CRT`) do set VC_REDIST_DLL_PATH=%%i
+
+echo Cleaning output directories
+rmdir /s /q %DEPLOY_FOLDER%
+rmdir /s /q %BUILD_FOLDER%
+rmdir /s /q %INSTALLER_FOLDER%
+rmdir /s /q %SYMBOLS_FOLDER%
+mkdir %BUILD_ROOT%
+mkdir %DEPLOY_FOLDER%
+mkdir %BUILD_FOLDER%
+mkdir %INSTALLER_FOLDER%
+mkdir %SYMBOLS_FOLDER%
+
+echo Configuring the project
+pushd %BUILD_FOLDER%
+%QMAKE_CMD% %SOURCE_ROOT%\moonlight-qt.pro
+if !ERRORLEVEL! NEQ 0 goto Error
+popd
+
+echo Compiling Artemis in %BUILD_CONFIG% configuration
+pushd %BUILD_FOLDER%
+if exist "%SOURCE_ROOT%\scripts\jom.exe" (
+    %SOURCE_ROOT%\scripts\jom.exe %BUILD_CONFIG%
+) else (
+    nmake %BUILD_CONFIG%
+)
+if !ERRORLEVEL! NEQ 0 goto Error
+popd
+
+echo Saving PDBs
+for /r "%BUILD_FOLDER%" %%f in (*.pdb) do (
+    copy "%%f" %SYMBOLS_FOLDER%
+    if !ERRORLEVEL! NEQ 0 goto Error
+)
+copy %SOURCE_ROOT%\libs\windows\lib\%ARCH%\*.pdb %SYMBOLS_FOLDER%
+if !ERRORLEVEL! NEQ 0 goto Error
+7z a %SYMBOLS_FOLDER%\ArtemisDebuggingSymbols-%ARCH%-%VERSION%.zip %SYMBOLS_FOLDER%\*.pdb
+if !ERRORLEVEL! NEQ 0 goto Error
+
+echo Copying DLL dependencies
+copy %SOURCE_ROOT%\libs\windows\lib\%ARCH%\*.dll %DEPLOY_FOLDER%
+if !ERRORLEVEL! NEQ 0 goto Error
+
+echo Copying AntiHooking.dll
+copy %BUILD_FOLDER%\AntiHooking\%BUILD_CONFIG%\AntiHooking.dll %DEPLOY_FOLDER%
+if !ERRORLEVEL! NEQ 0 goto Error
+
+echo Copying GC mapping list
+copy %SOURCE_ROOT%\app\SDL_GameControllerDB\gamecontrollerdb.txt %DEPLOY_FOLDER%
+if !ERRORLEVEL! NEQ 0 goto Error
+
+if not x%QT_PATH:\5.=%==x%QT_PATH% (
+    echo Copying qt.conf for Qt 5
+    copy %SOURCE_ROOT%\app\qt_qt5.conf %DEPLOY_FOLDER%\qt.conf
+    if !ERRORLEVEL! NEQ 0 goto Error
+
+    rem Qt 5.15
+    set WINDEPLOYQT_ARGS=--no-qmltooling --no-virtualkeyboard
+) else (
+    rem Qt 6.5+
+    set WINDEPLOYQT_ARGS=--no-system-d3d-compiler --no-system-dxc-compiler --skip-plugin-types qmltooling,generic --no-ffmpeg
+    set WINDEPLOYQT_ARGS=!WINDEPLOYQT_ARGS! --no-quickcontrols2fusion --no-quickcontrols2imagine --no-quickcontrols2universal
+    set WINDEPLOYQT_ARGS=!WINDEPLOYQT_ARGS! --no-quickcontrols2fusionstyleimpl --no-quickcontrols2imaginestyleimpl --no-quickcontrols2universalstyleimpl --no-quickcontrols2windowsstyleimpl
+)
+
+echo Deploying Qt dependencies
+%WINDEPLOYQT_CMD% --dir %DEPLOY_FOLDER% --%BUILD_CONFIG% --qmldir %SOURCE_ROOT%\app\gui --no-opengl-sw --no-compiler-runtime --no-sql %WINDEPLOYQT_ARGS% %BUILD_FOLDER%\app\%BUILD_CONFIG%\Moonlight.exe
+if !ERRORLEVEL! NEQ 0 goto Error
+
+echo Deleting unused styles
+rem Qt 5.x directories
+rmdir /s /q %DEPLOY_FOLDER%\QtQuick\Controls.2\Fusion
+rmdir /s /q %DEPLOY_FOLDER%\QtQuick\Controls.2\Imagine
+rmdir /s /q %DEPLOY_FOLDER%\QtQuick\Controls.2\Universal
+rem Qt 6.5+ directories
+rmdir /s /q %DEPLOY_FOLDER%\qml\QtQuick\Controls\Fusion
+rmdir /s /q %DEPLOY_FOLDER%\qml\QtQuick\Controls\Imagine
+rmdir /s /q %DEPLOY_FOLDER%\qml\QtQuick\Controls\Universal
+rmdir /s /q %DEPLOY_FOLDER%\qml\QtQuick\Controls\Windows
+rmdir /s /q %DEPLOY_FOLDER%\qml\QtQuick\NativeStyle
+
+if "%SIGN%"=="1" (
+    echo Signing deployed binaries
+    set FILES_TO_SIGN=%BUILD_FOLDER%\app\%BUILD_CONFIG%\Moonlight.exe
+    for /r "%DEPLOY_FOLDER%" %%f in (*.dll *.exe) do (
+        set FILES_TO_SIGN=!FILES_TO_SIGN! %%f
+    )
+    signtool %SIGNTOOL_PARAMS% !FILES_TO_SIGN!
+    if !ERRORLEVEL! NEQ 0 goto Error
+)
+
+echo Building MSI
+msbuild -Restore %SOURCE_ROOT%\wix\Artemis\Artemis.wixproj /p:Configuration=%BUILD_CONFIG% /p:Platform=%ARCH% /p:MSBuildProjectExtensionsPath=%BUILD_FOLDER%\
+if !ERRORLEVEL! NEQ 0 goto Error
+
+echo Copying application binary to deployment directory
+copy %BUILD_FOLDER%\app\%BUILD_CONFIG%\Moonlight.exe %DEPLOY_FOLDER%\Artemis.exe
+if !ERRORLEVEL! NEQ 0 goto Error
+
+echo Building portable package
+rem This must be done after WiX harvesting and signing, since the VCRT dlls are MS signed
+rem and should not be harvested for inclusion in the full installer
+copy "%VC_REDIST_DLL_PATH%\*.dll" %DEPLOY_FOLDER%
+if !ERRORLEVEL! NEQ 0 goto Error
+rem This file tells Artemis that it's a portable installation
+echo. > %DEPLOY_FOLDER%\portable.dat
+if !ERRORLEVEL! NEQ 0 goto Error
+7z a %INSTALLER_FOLDER%\ArtemisPortable-%ARCH%-%VERSION%.zip %DEPLOY_FOLDER%\*
+if !ERRORLEVEL! NEQ 0 goto Error
+
+echo Build successful for Artemis v%VERSION% %ARCH% binaries!
+exit /b 0
+
+:Error
+echo Build failed!
+exit /b !ERRORLEVEL!

--- a/wix/Artemis/Artemis.wixproj
+++ b/wix/Artemis/Artemis.wixproj
@@ -1,0 +1,23 @@
+<Project Sdk="WixToolset.Sdk/5.0.1" ToolsVersion="5.0">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutputPath>$(BUILD_FOLDER)\</OutputPath>
+    <IntermediateOutputPath>$(BUILD_FOLDER)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants>DeployDir=$(DEPLOY_FOLDER);BuildDir=$(BUILD_FOLDER)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(SIGN)!=''">
+    <SignOutput>true</SignOutput>
+  </PropertyGroup>
+  <Target Name="SignMsi">
+    <Exec Command='signtool.exe $(SIGNTOOL_PARAMS) %(SignMsi.FullPath)' />
+  </Target>
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Firewall.wixext" Version="5.0.1" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="5.0.1" />
+    <PackageReference Include="WixToolset.Heat" Version="5.0.1" />
+  </ItemGroup>
+</Project>

--- a/wix/Artemis/Product.wxs
+++ b/wix/Artemis/Product.wxs
@@ -1,0 +1,130 @@
+<?define ShortName = "Artemis" ?>
+<?define FullName = "Artemis Desktop Game Streaming Client" ?>
+
+<?define ShortcutName = "$(var.ShortName)" ?>
+<?define ShortcutDesc = "Stream games and other applications from another PC" ?>
+<?define InstallFolder = "Artemis Desktop" ?>
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:fire="http://wixtoolset.org/schemas/v4/wxs/firewall" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+
+  <Package Name="$(var.FullName)"
+           Language="1033"
+           Version="!(bind.fileVersion.ArtemisExe)"
+           Manufacturer="Artemis Desktop Project"
+           UpgradeCode="5c09f94e-f809-4c6a-9b7b-597c99f041fe">
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." Schedule="afterInstallInitialize" />
+    <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
+
+    <Property Id="MPSSVC_START">
+      <RegistrySearch Id="MpsSvcStart"
+                      Root="HKLM"
+                      Key="System\CurrentControlSet\Services\MpsSvc"
+                      Name="Start"
+                      Type="raw" />
+    </Property>
+
+    <Launch Condition="Installed OR MPSSVC_START=&quot;#2&quot;"
+            Message="Setup cannot proceed because the Windows Firewall service has been improperly disabled or stopped. You must start the Windows Firewall service (MpsSvc) to continue. If you would like to disable Windows Firewall properly, use the Windows Firewall options in Control Panel." />
+
+    <Property Id="APPDATAFOLDER" Value="%LOCALAPPDATA%\Artemis Desktop Project" />
+
+    <!-- There's no way to delete a registry key on uninstall but not major upgrade, so
+        we have to roll our own deletion via custom action -->
+    <CustomAction Id="DeleteRegistryKey"
+                  Directory="ProgramFiles6432Folder"
+                  ExeCommand="reg.exe delete &quot;HKCU\Software\Artemis Desktop Project&quot; /f"
+                  Execute="deferred"
+                  Return="ignore"
+                  Impersonate="yes" />
+    <InstallExecuteSequence>
+      <Custom Action="DeleteRegistryKey"
+              Before="InstallFinalize"
+              Condition="Installed AND REMOVE~=&quot;ALL&quot; AND NOT UPGRADINGPRODUCTCODE" />
+    </InstallExecuteSequence>
+
+    <Component Id="ArtemisShortcuts" Directory="INSTALLFOLDER">
+      <Shortcut Id="StartMenuShortcut"
+                Name="$(var.ShortcutName)"
+                Description="$(var.ShortcutDesc)"
+                Target="[#ArtemisExe]"
+                Directory="ApplicationProgramsFolder"
+                WorkingDirectory="INSTALLFOLDER" />
+      <RemoveFolder Id="CleanupStartMenuShortcut"
+                    Directory="ApplicationProgramsFolder"
+                    On="uninstall" />
+      <util:RemoveFolderEx Id="CleanupAppDataFolder"
+                           On="uninstall"
+                           Property="APPDATAFOLDER" />
+      <RegistryValue Root="HKCU"
+                     Key="Software\Artemis Desktop Project"
+                     Name="Installed"
+                     Type="integer"
+                     Value="1"
+                     KeyPath="yes" />
+    </Component>
+
+    <Component Id="ArtemisDesktopShortcut" Directory="INSTALLFOLDER" Condition="ADDDESKTOPSHORTCUT=1">
+      <Shortcut Id="DesktopShortcut"
+                Name="$(var.ShortcutName)"
+                Description="$(var.ShortcutDesc)"
+                Target="[#ArtemisExe]"
+                Directory="DesktopFolder"
+                WorkingDirectory="INSTALLFOLDER" />
+      <RemoveFolder Id="CleanupDesktopShortcut"
+                    Directory="DesktopFolder"
+                    On="uninstall" />
+      <RegistryValue Root="HKCU"
+                     Key="Software\Artemis Desktop Project"
+                     Name="DesktopShortcutInstalled"
+                     Type="integer"
+                     Value="1"
+                     KeyPath="yes" />
+    </Component>
+
+    <!-- Persist desktop shortcut's installed state to let Bundle.wxs know if
+         the desktop shortcut should installed by default when upgrading the
+         product -->
+    <Component Id="ArtemisDesktopShortcutState" Directory="INSTALLFOLDER">
+      <RegistryValue Root="HKCU"
+                     Key="Software\Artemis Desktop Project"
+                     Name="DesktopShortcutInstallState"
+                     Type="integer"
+                     Value="[ADDDESKTOPSHORTCUT]"
+                     KeyPath="yes" />
+    </Component>
+
+    <DirectoryRef Id="INSTALLFOLDER">
+      <Component Id="Artemis">
+        <File Id="ArtemisExe"
+              KeyPath="yes"
+              Checksum="yes"
+              Source="$(var.BuildDir)\app\$(var.Configuration)\Moonlight.exe">
+          <fire:FirewallException Id="ArtemisFirewallException"
+                                  Scope="any"
+                                  IgnoreFailure="yes"
+                                  Name="$(var.FullName)" />
+        </File>
+      </Component>
+    </DirectoryRef>
+
+    <ComponentGroup Id="ArtemisDependencies" Directory="INSTALLFOLDER">
+      <Files Include="$(var.DeployDir)\**" />
+    </ComponentGroup>
+
+    <Feature Id="ProductFeature" Title="Artemis" Level="1" ConfigurableDirectory="INSTALLFOLDER">
+      <ComponentRef Id="Artemis" />
+      <ComponentRef Id="ArtemisShortcuts" />
+      <ComponentRef Id="ArtemisDesktopShortcutState" />
+      <ComponentRef Id="ArtemisDesktopShortcut" />
+      <ComponentGroupRef Id="ArtemisDependencies" />
+    </Feature>
+
+    <StandardDirectory Id="DesktopFolder" />
+    <StandardDirectory Id="ProgramFiles6432Folder">
+      <Directory Id="INSTALLFOLDER" Name="$(var.InstallFolder)" />
+    </StandardDirectory>
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="ApplicationProgramsFolder" Name="$(var.InstallFolder)" />
+    </StandardDirectory>
+  </Package>
+</Wix>


### PR DESCRIPTION
- Replace manual DLL copying with comprehensive build-artemis-arch.bat script
- Add Artemis-specific WiX configuration files (Product.wxs, Artemis.wixproj)
- Install WiX Toolset 5.0.1 via Chocolatey in GitHub Actions
- Generate both MSI installer and portable ZIP packages
- Properly handle all Windows runtime dependencies via windeployqt
- Use same proven build approach as original Moonlight project

This addresses the missing DLL dependencies issue identified by Dependency Walker by switching from ad-hoc manual packaging to the comprehensive WiX-based installer build system that properly collects and packages all required dependencies.