### PR TITLE
fix: WiX Toolset installation and build process

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -56,9 +56,14 @@ jobs:
     
     - name: Install WiX Toolset
       run: |
-        choco install wixtoolset --version=5.0.1 -y
-        # Add WiX to PATH
-        echo "C:\Program Files (x86)\WiX Toolset v5.0\bin" >> $env:GITHUB_PATH
+        # Install .NET SDK first (required for WiX v5)
+        choco install dotnet-sdk -y
+        
+        # Install WiX Toolset v5 as a .NET tool (recommended approach for v5)
+        dotnet tool install --global wix --version 5.0.1
+        
+        # Verify installation
+        wix --version
     
     - name: Setup MSVC
       uses: ilammy/msvc-dev-cmd@v1
@@ -672,7 +677,7 @@ jobs:
     - name: Get version info
       id: version
       run: |
-        VERSION="v0.1.2-dev-${{ github.run_number }}-${GITHUB_SHA:0:7}"
+        VERSION="v0.1.3-dev-${{ github.run_number }}-${GITHUB_SHA:0:7}"
         echo "version=${VERSION}" >> $GITHUB_OUTPUT
         echo "Generated version: ${VERSION}"
 

--- a/scripts/build-artemis-arch.bat
+++ b/scripts/build-artemis-arch.bat
@@ -217,7 +217,9 @@ if "%SIGN%"=="1" (
 )
 
 echo Building MSI
-msbuild -Restore %SOURCE_ROOT%\wix\Artemis\Artemis.wixproj /p:Configuration=%BUILD_CONFIG% /p:Platform=%ARCH% /p:MSBuildProjectExtensionsPath=%BUILD_FOLDER%\
+set DEPLOY_FOLDER=%DEPLOY_FOLDER%
+set BUILD_FOLDER=%BUILD_FOLDER%
+msbuild %SOURCE_ROOT%\wix\Artemis\Artemis.wixproj /p:Configuration=%BUILD_CONFIG% /p:Platform=%ARCH% /p:OutputPath=%INSTALLER_FOLDER%\ /p:DEPLOY_FOLDER=%DEPLOY_FOLDER% /p:BUILD_FOLDER=%BUILD_FOLDER%
 if !ERRORLEVEL! NEQ 0 goto Error
 
 echo Copying application binary to deployment directory

--- a/wix/Artemis/Artemis.wixproj
+++ b/wix/Artemis/Artemis.wixproj
@@ -3,11 +3,11 @@
     <DefineConstants>Debug</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <OutputPath>$(BUILD_FOLDER)\</OutputPath>
-    <IntermediateOutputPath>$(BUILD_FOLDER)\</IntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)' == ''">$(BUILD_FOLDER)\</OutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BUILD_FOLDER)\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants>DeployDir=$(DEPLOY_FOLDER);BuildDir=$(BUILD_FOLDER)</DefineConstants>
+    <DefineConstants>DeployDir=$(DEPLOY_FOLDER);BuildDir=$(BUILD_FOLDER);Configuration=$(Configuration)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="$(SIGN)!=''">
     <SignOutput>true</SignOutput>


### PR DESCRIPTION
- Install WiX v5 as .NET global tool instead of Chocolatey package
- Install .NET SDK as prerequisite for WiX v5
- Update WiX project file with proper environment variable handling
- Fix MSBuild command parameters for WiX build process

WiX v5 changed from traditional installer to .NET global tool distribution, requiring updated installation and build approach.