### PR TITLE
fix: use deep copy for SSL key to prevent use-after-free

### DIFF
--- a/app/backend/identitymanager.cpp
+++ b/app/backend/identitymanager.cpp
@@ -173,7 +173,7 @@ IdentityManager::getSslKey()
 
         BUF_MEM* mem;
         BIO_get_mem_ptr(bio, &mem);
-        m_CachedSslKey = QSslKey(QByteArray::fromRawData(mem->data, (int)mem->length), QSsl::Rsa);
+        m_CachedSslKey = QSslKey(QByteArray(mem->data, (int)mem->length), QSsl::Rsa);
 
         BIO_free(bio);
         EVP_PKEY_free(pk);


### PR DESCRIPTION
## Summary

Fix a use-after-free vulnerability in  in .

## Problem

 creates a shallow (non-owning) copy that points directly into the BIO memory buffer. When  is called immediately after, the underlying buffer is freed — leaving  holding a dangling pointer. Any subsequent use of the cached key reads freed memory.

## Fix

Replace  with the standard  constructor, which performs a deep copy of the buffer contents before  is called.



This same issue was fixed in upstream moonlight-qt in commit  (2026-05-16).